### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,13 @@ the `#hackedu` IRC where his nick is `zrl`. It is recommended to take things off
 the backlog, and check in with the team at the daily "sprint checkin".
 
 * Sprint duration: 1 week
-* Sprint discuss: Mondays at `18:00-19:00 UTC` via +hangout (link posted in IRC)
-* Sprint checkin: daily at `18:00-18:05 UTC` on `#hackedu` IRC (Freenode)
+* Sprint discuss: Mondays at `5:00pm PST`, `8:00pm EST` via +hangout (link will be posted in #hackedu irc channel)
+* Sprint standups: Monday - Friday at `11:00am PST`, `2:00pm PST` on `#hackedu-standups` on IRC (Freenode)
+  * if you can't make the checkin, just post in #hackedu-standups before the syncup
+  * contents of syncup:
+    * what did you work on yesterday?
+    * what are you working on today?
+    * is there anything that is blocking you?
 
 Each sprint will be synthesized into an issue in this repo, as described in
 https://www.zenhub.io/blog/how-the-zenhub-team-uses-zenhub-boards-on-github/#keepingarecordofsprints.


### PR DESCRIPTION
@benzweig @gemmabusoni: When's the earliest time that you can do a 1 hours syncup on Monday in person (this will basically be our plan for the week)?

Changed the 
- times (so that people in school can make it in California)
- timezone format to PST and EST, where most of our audience is so it's easier to read. I think it could be premature optimization to use UTC time. May make more sense to not have a regional bias when we become more international.
- name change from checkins => standups (just to not create something new). Seems like it's basically the same thing
- moved standups to a channel from (#hackedu => #hackedu-standups). Thought it would be better to keep these in a different channel because
  - if  someone needed to post to the standup earlier, their post could be lost in the main #hackedu because there could be many chat messages in the interim
  - Also it's nice to be able to see everyone's standup in one place day even for a given day and be able to reference it in the future.
